### PR TITLE
Staging/integracao sentry

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -9,6 +9,7 @@ on:
       - "pipelines/**/*"
       - "pyproject.toml"
       - "Dockerfile"
+      - "queries/**"
   pull_request:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - "pipelines/**/*"
       - "pyproject.toml"
       - "Dockerfile"
+      - "queries/**"
 
 jobs:
   build-container:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,6 +9,7 @@ on:
       - "pipelines/**/*"
       - "pyproject.toml"
       - "Dockerfile"
+      - "queries/**"
 
 env:
   PREFECT__BACKEND: cloud

--- a/pipelines/cerco_digital/auxiliary_tables/flows.py
+++ b/pipelines/cerco_digital/auxiliary_tables/flows.py
@@ -8,45 +8,88 @@ from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
 from prefect.utilities.edges import unmapped
 from prefeitura_rio.pipelines_utils.custom import Flow
 from prefeitura_rio.pipelines_utils.prefect import task_get_current_flow_run_labels
-from prefeitura_rio.pipelines_utils.state_handlers import (  # handler_initialize_sentry,
-    handler_skip_if_running,
-)
+from prefeitura_rio.pipelines_utils.state_handlers import handler_skip_if_running
 from prefeitura_rio.pipelines_utils.tasks import get_current_flow_project_name
 
 from pipelines.cerco_digital.auxiliary_tables.schedules import (
     auxiliary_tables_daily_update_schedule,
 )
+from pipelines.cerco_digital_staging.radar.flows import materialize_radar
 from pipelines.constants import FLOW_RUN_CONFIG, FLOW_STORAGE, constants
 from pipelines.utils.state_handlers import (
     handler_inject_bd_credentials,
     handler_notify_on_failure,
 )
-from pipelines.utils.tasks import task_get_secret_folder
+from pipelines.utils.tasks import (
+    add_default_start_date_to_dbt_vars,
+    task_get_secret_folder,
+)
 
 # Define the Prefect Flow for data extraction and transformation
 with Flow(
     name="CIVITAS: cerco digital - Materialização das tabelas auxiliares",
     state_handlers=[
         handler_inject_bd_credentials,
-        # handler_initialize_sentry,
         handler_skip_if_running,
         handler_notify_on_failure,
     ],
 ) as materialize_auxiliary_tables:
+
+    #####################################
+    # Secrets
+    #####################################
+
     SECRETS = task_get_secret_folder(secret_path="/discord", inject_env=True)
+    PIPELINE_SECRETS = task_get_secret_folder(secret_path="/radar")
+
+    #####################################
+    # Parameters
+    #####################################
 
     DATASET_ID = Parameter("dataset_id", default="cerco_digital")
     EXCLUDE = Parameter("exclude", default="vw_readings")
     VARS = Parameter("vars", default=[])
+    COMPUTED_VARS = add_default_start_date_to_dbt_vars(VARS)
 
-    materialization_flow_name = constants.FLOW_NAME_DBT_TRANSFORM.value
+    #####################################
+    # Materialize Radar Staging Table
+    #####################################
+    materialize_radar_flow_name = materialize_radar.name
     materialization_labels = task_get_current_flow_run_labels()
 
+    materialize_radar_parameters = [
+        {
+            "DATASET_ID": DATASET_ID,
+            "TABLE_ID": "radar",
+            "DUMP_MODE": "overwrite",
+        }
+    ]
+
+    current_flow_project_name = get_current_flow_project_name()
+
+    materialize_radar_flow_runs = create_flow_run.map(
+        flow_name=unmapped(materialize_radar_flow_name),
+        project_name=unmapped(current_flow_project_name),
+        parameters=materialize_radar_parameters,
+        labels=unmapped(materialization_labels),
+    )
+
+    materialize_radar_wait_for_flow_run = wait_for_flow_run.map(
+        flow_run_id=materialize_radar_flow_runs,
+        stream_states=unmapped(True),
+        stream_logs=unmapped(True),
+        raise_final_state=unmapped(True),
+    )
+
+    #####################################
+    # Materialize Tables
+    #####################################
+    materialization_flow_name = constants.FLOW_NAME_DBT_TRANSFORM.value
     dump_prod_tables_to_materialize_parameters = [
         {
             "select": DATASET_ID,
             "exclude": EXCLUDE,
-            "vars": VARS,
+            "vars": COMPUTED_VARS,
         }
     ]
 
@@ -58,6 +101,7 @@ with Flow(
         parameters=dump_prod_tables_to_materialize_parameters,
         labels=unmapped(materialization_labels),
     )
+    dump_prod_materialization_flow_runs.set_upstream(materialize_radar_wait_for_flow_run)
 
     dump_prod_wait_for_flow_run = wait_for_flow_run.map(
         flow_run_id=dump_prod_materialization_flow_runs,

--- a/pipelines/cerco_digital/auxiliary_tables/schedules.py
+++ b/pipelines/cerco_digital/auxiliary_tables/schedules.py
@@ -3,7 +3,7 @@
 Schedules for the database dump pipeline.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import pytz
 from prefect.schedules import Schedule
@@ -12,17 +12,10 @@ from prefeitura_rio.pipelines_utils.io import untuple_clocks as untuple
 
 from pipelines.constants import constants
 
-exclude_models = ["vw_readings", "radar", "equipamento_codcet_camera_numero"]
+exclude_models = ["vw_readings", "equipamento_codcet_camera_numero"]
 parameters = {
     "dataset_id": "cerco_digital",
     "exclude": " ".join(exclude_models),
-    "vars": [
-        {
-            "start_date": (datetime.now(tz=timezone.utc) - timedelta(hours=1)).strftime(
-                "%Y-%m-%d %H:00:00"
-            )
-        }
-    ],
 }
 
 auxiliary_tables_daily_clocks = [

--- a/pipelines/cerco_digital/auxiliary_tables/schedules.py
+++ b/pipelines/cerco_digital/auxiliary_tables/schedules.py
@@ -12,7 +12,7 @@ from prefeitura_rio.pipelines_utils.io import untuple_clocks as untuple
 
 from pipelines.constants import constants
 
-exclude_models = ["vw_readings", "equipamento_codcet_camera_numero"]
+exclude_models = ["vw_readings", "equipamento_codcet_camera_numero", "radares_cameras_proximas"]
 parameters = {
     "dataset_id": "cerco_digital",
     "exclude": " ".join(exclude_models),

--- a/pipelines/cerco_digital/readings/flows.py
+++ b/pipelines/cerco_digital/readings/flows.py
@@ -17,7 +17,10 @@ from pipelines.utils.state_handlers import (
     handler_inject_bd_credentials,
     handler_notify_on_failure,
 )
-from pipelines.utils.tasks import task_get_secret_folder
+from pipelines.utils.tasks import (
+    add_default_start_date_to_dbt_vars,
+    task_get_secret_folder,
+)
 
 # Define the Prefect Flow for data extraction and transformation
 with Flow(
@@ -36,7 +39,8 @@ with Flow(
 
     # DBT
     SELECT = Parameter("select", default=None)
-    VARS = Parameter("vars", default=None)
+    VARS = Parameter("vars", default=[])
+    COMPUTED_VARS = add_default_start_date_to_dbt_vars(VARS)
 
     materialization_labels = task_get_current_flow_run_labels()
     materialization_flow_name = constants.FLOW_NAME_DBT_TRANSFORM.value
@@ -44,7 +48,7 @@ with Flow(
     materialization_parameters = [
         {
             "select": SELECT,
-            "vars": VARS,
+            "vars": COMPUTED_VARS,
         },
     ]
 

--- a/pipelines/cerco_digital/readings/schedules.py
+++ b/pipelines/cerco_digital/readings/schedules.py
@@ -3,7 +3,7 @@
 Schedules for the "CIVITAS: radares_infra - Materialização das tabelas" pipeline..
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime
 
 import pytz
 from prefect.schedules import Schedule
@@ -13,16 +13,7 @@ from prefeitura_rio.pipelines_utils.io import untuple_clocks as untuple
 from pipelines.constants import constants
 
 tz = pytz.timezone("America/Sao_Paulo")
-parameters = {
-    "select": "vw_readings",
-    "vars": [
-        {
-            "start_date": (datetime.now(tz=timezone.utc) - timedelta(hours=1)).strftime(
-                "%Y-%m-%d %H:00:00"
-            )
-        }
-    ],
-}
+parameters = {"select": "vw_readings"}
 
 
 readings_clocks = [

--- a/pipelines/cerco_digital_staging/radar/flows.py
+++ b/pipelines/cerco_digital_staging/radar/flows.py
@@ -4,22 +4,15 @@ This module defines a Prefect workflow for materializing tables using DBT.....
 """
 
 from prefect import Parameter
-from prefect.tasks.prefect import create_flow_run, wait_for_flow_run
-from prefect.utilities.edges import unmapped
 from prefeitura_rio.pipelines_utils.custom import Flow
 from prefeitura_rio.pipelines_utils.prefect import (
-    task_get_current_flow_run_labels,
     task_rename_current_flow_run_dataset_table,
 )
 from prefeitura_rio.pipelines_utils.state_handlers import handler_skip_if_running
-from prefeitura_rio.pipelines_utils.tasks import (
-    create_table_and_upload_to_gcs,
-    get_current_flow_project_name,
-)
+from prefeitura_rio.pipelines_utils.tasks import create_table_and_upload_to_gcs
 
-from pipelines.cerco_digital_staging.radar.schedules import radar_schedule
 from pipelines.cerco_digital_staging.radar.tasks import extract_radar_data
-from pipelines.constants import FLOW_RUN_CONFIG, FLOW_STORAGE, constants
+from pipelines.constants import FLOW_RUN_CONFIG, FLOW_STORAGE
 from pipelines.utils.state_handlers import (
     handler_inject_bd_credentials,
     handler_notify_on_failure,
@@ -41,14 +34,9 @@ with Flow(
     # Parameters
     #####################################
 
-    PROJECT_ID = Parameter("project_id", default="rj-civitas")
     DATASET_ID = Parameter("dataset_id", default="cerco_digital")
     TABLE_ID = Parameter("table_id", default="radar")
     DUMP_MODE = Parameter("dump_mode", default="overwrite")
-
-    # DBT
-    SELECT = Parameter("select", default="cerco_digital.radar")
-    VARS = Parameter("vars", default=None)
 
     rename_flow_run = task_rename_current_flow_run_dataset_table(
         prefix="ELT_",
@@ -73,40 +61,9 @@ with Flow(
         biglake_table=True,
     )
 
-    #####################################
-    # Create Flow Runs
-    #####################################
-
-    materialization_labels = task_get_current_flow_run_labels()
-    materialization_flow_name = constants.FLOW_NAME_DBT_TRANSFORM.value
-
-    materialization_parameters = [
-        {
-            "select": SELECT,
-            "vars": VARS,
-        },
-    ]
-    current_flow_project_name = get_current_flow_project_name()
-
-    materialization_flow_runs = create_flow_run.map(
-        flow_name=unmapped(materialization_flow_name),
-        project_name=unmapped(current_flow_project_name),
-        parameters=materialization_parameters,
-        labels=unmapped(materialization_labels),
-    )
-
-    materialization_wait_for_flow_run = wait_for_flow_run.map(
-        flow_run_id=materialization_flow_runs,
-        stream_states=unmapped(True),
-        stream_logs=unmapped(True),
-        raise_final_state=unmapped(True),
-    )
-
 #####################################
 # Set Storage and Run Config
 #####################################
 
 materialize_radar.storage = FLOW_STORAGE
 materialize_radar.run_config = FLOW_RUN_CONFIG
-
-materialize_radar.schedule = radar_schedule

--- a/pipelines/cerco_digital_staging/radar/schedules.py
+++ b/pipelines/cerco_digital_staging/radar/schedules.py
@@ -13,7 +13,7 @@ from prefeitura_rio.pipelines_utils.io import untuple_clocks as untuple
 from pipelines.constants import constants
 
 tz = pytz.timezone("America/Sao_Paulo")
-parameters = {"select": "cerco_digital_staging.radar"}
+parameters = {"select": "cerco_digital.radar"}
 
 
 radar_clocks = [

--- a/pipelines/templates/dbt_transform/flows.py
+++ b/pipelines/templates/dbt_transform/flows.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# ........................
+# ...........................
 from prefect import Parameter, case
 from prefeitura_rio.pipelines_utils.custom import Flow
 from prefeitura_rio.pipelines_utils.tasks import get_current_flow_project_name

--- a/pipelines/templates/run_dbt_model/flows.py
+++ b/pipelines/templates/run_dbt_model/flows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 
-MATERIALIZA MODELOS DO DBT..............................................
+MATERIALIZA MODELOS DO DBT............................................
 
 """
 

--- a/pipelines/templates/run_dbt_model/flows.py
+++ b/pipelines/templates/run_dbt_model/flows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 
-MATERIALIZA MODELOS DO DBT.........
+MATERIALIZA MODELOS DO DBT......
 
 """
 

--- a/pipelines/templates/run_dbt_model/flows.py
+++ b/pipelines/templates/run_dbt_model/flows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 
-MATERIALIZA MODELOS DO DBT......
+MATERIALIZA MODELOS DO DBT..............................................
 
 """
 

--- a/pipelines/utils/tasks.py
+++ b/pipelines/utils/tasks.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime, timezone
 from typing import Literal
 
 from infisical import InfisicalClient
@@ -51,3 +52,23 @@ def task_get_secret_folder(
         inject_env_vars(secrets)
 
     return secrets
+
+
+@task
+def add_default_start_date_to_dbt_vars(vars: list[dict]) -> list[dict]:
+    """
+    Adds a default start_date to the vars list.
+
+    The default start_date is the current hour with minute, second and microsecond set to 0.
+
+    Args:
+        vars (list[dict]): The list of variables to add the default start_date to.
+
+    Returns:
+        list[dict]: The list of variables with the default start_date added.
+    """
+    now = datetime.now(tz=timezone.utc)
+    start_date = now.replace(minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:00:00")
+    result = list(vars) if vars else []
+    result.append({"start_date": start_date})
+    return result

--- a/queries/models/cerco_digital/equipamento_ponto_coleta_lpr.sql
+++ b/queries/models/cerco_digital/equipamento_ponto_coleta_lpr.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized='table',
+        cluster_by = ["id_ponto_coleta", "codigo_equipamento"]
+    )
+}}
+-- Uma linha por equipamento com o id_ponto_coleta resolvido (chave de negócio → ID interno).
+SELECT
+  m.id_ponto_coleta,
+  e.origem_equipamento,
+  e.codigo_equipamento,
+  e.codigo_ponto_coleta,
+  e.sentido,
+  e.local,
+  e.bairro,
+  e.latitude,
+  e.longitude,
+  e.geography,
+  e.status_ativo
+FROM {{ ref('equipamento') }} AS e
+INNER JOIN {{ ref('mapeamento_id_ponto_coleta') }} AS m
+  ON e.origem_equipamento = m.origem_equipamento
+ AND e.codigo_ponto_coleta = m.codigo_ponto_coleta
+ AND e.sentido = m.sentido

--- a/queries/models/cerco_digital/ponto_coleta_lpr_camera_proxima.sql
+++ b/queries/models/cerco_digital/ponto_coleta_lpr_camera_proxima.sql
@@ -1,0 +1,76 @@
+{{
+    config(
+        materialized='table',
+        cluster_by = ["id_ponto_coleta"]
+    )
+}}
+
+WITH pontos AS (
+  SELECT
+    id_ponto_coleta,
+    origem_equipamento AS origem_equipamento_lpr,
+    codigo_ponto_coleta,
+    local,
+    bairro,
+    sentido,
+    latitude AS latitude_equip_lpr,
+    longitude AS longitude_equip_lpr,
+    ST_GEOGPOINT(SAFE_CAST(longitude AS FLOAT64), SAFE_CAST(latitude AS FLOAT64)) AS position
+  FROM {{ ref('ponto_coleta_lpr') }}
+),
+
+cameras AS (
+  SELECT
+    codigo_camera AS id_camera,
+    nome_camera,
+    latitude,
+    longitude,
+    ST_GEOGPOINT(longitude, latitude) AS position,
+    streaming_url,
+    sistema_origem AS sistema_origem_camera
+  FROM {{ ref('cameras') }}
+),
+
+ranked_cameras AS (
+  SELECT
+    t2.id_ponto_coleta,
+    t2.origem_equipamento_lpr,
+    t2.codigo_ponto_coleta,
+    t2.sentido,
+    t2.local,
+    t2.bairro,
+    t2.latitude_equip_lpr,
+    t2.longitude_equip_lpr,
+    t1.id_camera,
+    t1.nome_camera,
+    t1.streaming_url,
+    t1.sistema_origem_camera,
+    t1.latitude,
+    t1.longitude,
+    ST_DISTANCE(t1.position, t2.position) AS distance,
+    ROW_NUMBER() OVER (PARTITION BY t2.id_ponto_coleta ORDER BY ST_DISTANCE(t1.position, t2.position)) AS rank
+  FROM pontos t2
+  LEFT JOIN  cameras t1
+    ON ST_DWithin(t1.position, t2.position, 100000) -- Large enough distance to include all relevant cameras
+  QUALIFY rank <= 5
+)
+
+  SELECT
+    id_ponto_coleta,
+    origem_equipamento_lpr,
+    codigo_ponto_coleta,
+    sentido,
+    COALESCE(UPPER(local), 'Desconhecido') local,
+    COALESCE(UPPER(bairro), 'Desconhecido') bairro,
+    latitude_equip_lpr,
+    longitude_equip_lpr,
+    id_camera,
+    nome_camera,
+    sistema_origem_camera,
+    streaming_url,
+    latitude,
+    longitude,
+    distance,
+    rank
+  FROM ranked_cameras
+  WHERE nome_camera is not null

--- a/queries/models/cerco_digital/radares_cameras_proximas.sql
+++ b/queries/models/cerco_digital/radares_cameras_proximas.sql
@@ -8,7 +8,7 @@
         cluster_by = ["codcet"]
     )
 }}
-
+-- Tabela de radares com as câmeras mais próximas
 WITH radars AS (
   SELECT
     codcet,

--- a/queries/models/cerco_digital/radares_cameras_proximas.sql
+++ b/queries/models/cerco_digital/radares_cameras_proximas.sql
@@ -55,7 +55,7 @@ selected_radar AS (
 
 cameras AS (
   SELECT
-    id_camera,
+    codigo_camera,
     nome_camera,
     latitude,
     longitude,
@@ -71,7 +71,7 @@ ranked_cameras AS (
     t2.bairro,
     t2.latitude_radar,
     t2.longitude_radar,
-    t1.id_camera,
+    t1.codigo_camera,
     t1.nome_camera,
     t1.streaming_url,
     t1.latitude,
@@ -90,7 +90,7 @@ ranked_cameras AS (
     COALESCE(UPPER(bairro), 'Desconhecido') bairro,
     latitude_radar,
     longitude_radar,
-    id_camera,
+    codigo_camera AS id_camera,
     nome_camera,
     streaming_url,
     latitude,

--- a/queries/models/cerco_digital/schema.yml
+++ b/queries/models/cerco_digital/schema.yml
@@ -360,6 +360,108 @@ models:
       - name: rank
         description: "Rank da câmera."
 
+  - name: ponto_coleta_lpr_camera_proxima
+    description: |
+      **Descrição**: Tabela que relaciona pontos de coleta (equipamentos LPR) às câmeras mais próximas.
+      **Frequência de atualização**: Diária
+      **Publicado por**: Nicolas Evilasio
+      **Publicado por (email)**: nicolas.evilasio@prefeitura.rio
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          name: ponto_coleta_lpr_camera_proxima__unique_combination_of_columns
+          combination_of_columns:
+            - id_ponto_coleta
+            - id_camera
+
+    columns:
+      - name: id_ponto_coleta
+        description: "Identificador canónico do ponto de coleta (dimensão `ponto_coleta_lpr`)."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__id_ponto_coleta__not_null
+              meta:
+                description: "Verifica se id_ponto_coleta não é nulo"
+
+      - name: origem_equipamento_lpr
+        description: "Origem do equipamento (CETRIO / CIVITAS)."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__origem_equipamento_lpr__not_null
+              meta:
+                description: "Verifica se origem_equipamento_lpr não é nulo"
+
+      - name: codigo_ponto_coleta
+        description: "Código de negócio do ponto de coleta (texto, não confundir com código de equipamento)."
+
+      - name: sentido
+        description: "Sentido da via no ponto de coleta."
+
+      - name: local
+        description: "Local do ponto de coleta."
+
+      - name: bairro
+        description: "Bairro do ponto de coleta."
+
+      - name: latitude_equip_lpr
+        description: "Latitude do ponto de coleta (equipamento LPR)."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__latitude_equip_lpr__not_null
+              meta:
+                description: "Verifica se latitude_equip_lpr não é nulo"
+
+      - name: longitude_equip_lpr
+        description: "Longitude do ponto de coleta (equipamento LPR)."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__longitude_equip_lpr__not_null
+              meta:
+                description: "Verifica se longitude_equip_lpr não é nulo"
+
+      - name: id_camera
+        description: "Código identificador da câmera."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__id_camera__not_null
+              meta:
+                description: "Verifica se id_camera não é nulo"
+
+      - name: nome_camera
+        description: "Nome da câmera."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__nome_camera__not_null
+              meta:
+                description: "Verifica se nome_camera não é nulo"
+
+      - name: sistema_origem_camera
+        description: "Sistema de origem da câmera (ex. TIXXI, DC3)."
+
+      - name: streaming_url
+        description: "URL de streaming da câmera."
+
+      - name: latitude
+        description: "Latitude da câmera."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__latitude__not_null
+              meta:
+                description: "Verifica se latitude não é nulo"
+
+      - name: longitude
+        description: "Longitude da câmera."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: ponto_coleta_lpr_camera_proxima__longitude__not_null
+              meta:
+                description: "Verifica se longitude não é nulo"
+
+      - name: distance
+        description: "Distância entre o ponto de coleta (equipamento LPR) e a câmera."
+
+      - name: rank
+        description: "Rank da câmera (1 a 5 mais próximas)."
+
   - name: equipamento_codcet_camera_numero
     description: |
       **Descrição**: Tabela que relaciona os códigos de equipamento com os números de câmera.
@@ -856,7 +958,7 @@ models:
       View que consolida e normaliza os dados dos pontos de coleta da CETRIO e CIVITAS e traz métricas de leituras por ponto de coleta.
       Atenção: Utilizar esta view para consultas que necessitam de métricas de leituras por ponto de coleta.
       Caso contrario, utilizar a tabela ponto_coleta_lpr.
-      
+
       Publicado por: Nicolas Evilasio
       Publicado por (email): nicolas.evilasio@prefeitura.rio
 
@@ -866,34 +968,34 @@ models:
 
       - name: origem_equipamento
         description: "Origem do equipamento."
-      
+
       - name: codigo_ponto_coleta
         description: "Código do ponto de coleta."
 
       - name: local
         description: "Local do ponto de coleta."
-     
+
       - name: bairro
         description: "Bairro do ponto de coleta."
-      
+
       - name: sentido
         description: "Sentido do ponto de coleta."
-      
+
       - name: latitude
         description: "Latitude do ponto de coleta."
-      
+
       - name: longitude
         description: "Longitude do ponto de coleta."
       - name: status_ativo
 
       - name: status_ativo
         description: "Status ativo do ponto de coleta."
-      
+
       - name: datahora_ultima_leitura
         description: "Data e hora da última leitura do ponto de coleta."
-      
+
       - name: total_leituras
         description: "Total de leituras do ponto de coleta."
-      
+
       - name: ativo_ultimas_24h
         description: "Indica se o ponto de coleta está ativo nas últimas 24 horas."

--- a/queries/models/cerco_digital/schema.yml
+++ b/queries/models/cerco_digital/schema.yml
@@ -602,6 +602,77 @@ models:
               meta:
                 description: "Verifica se status_ativo não é nulo"
 
+  - name: equipamento_ponto_coleta_lpr
+    description: |
+      **Descrição**: Ponte entre cada equipamento (`equipamento`) e o identificador canónico do ponto de coleta (`id_ponto_coleta` em `mapeamento_id_ponto_coleta`). Uma linha por equipamento com chave de negócio completa (origem, codigo_ponto_coleta, sentido).
+      **Frequência de atualização**: Diária (segue `equipamento` e `mapeamento_id_ponto_coleta`).
+      **Publicado por**: Nicolas Evilasio
+      **Publicado por (email)**: nicolas.evilasio@prefeitura.rio
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - origem_equipamento
+            - codigo_equipamento
+
+    columns:
+      - name: id_ponto_coleta
+        description: "Identificador estável do ponto de coleta (dimensão)."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: equipamento_ponto_coleta_lpr__id_ponto_coleta__not_null
+              meta:
+                description: "Verifica se id_ponto_coleta não é nulo"
+
+      - name: origem_equipamento
+        description: "Origem do equipamento (CETRIO / CIVITAS)."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: equipamento_ponto_coleta_lpr__origem_equipamento__not_null
+              meta:
+                description: "Verifica se origem_equipamento não é nulo"
+
+      - name: codigo_equipamento
+        description: "Código do equipamento na origem."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: equipamento_ponto_coleta_lpr__codigo_equipamento__not_null
+              meta:
+                description: "Verifica se codigo_equipamento não é nulo"
+
+      - name: codigo_ponto_coleta
+        description: "Código de negócio do ponto de coleta."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: equipamento_ponto_coleta_lpr__codigo_ponto_coleta__not_null
+              meta:
+                description: "Verifica se codigo_ponto_coleta não é nulo"
+
+      - name: sentido
+        description: "Sentido da via."
+        tests:
+          - dbt_expectations.expect_column_values_to_not_be_null:
+              name: equipamento_ponto_coleta_lpr__sentido__not_null
+              meta:
+                description: "Verifica se sentido não é nulo"
+
+      - name: local
+        description: "Local do equipamento."
+
+      - name: bairro
+        description: "Bairro do equipamento."
+
+      - name: latitude
+        description: "Latitude do equipamento."
+
+      - name: longitude
+        description: "Longitude do equipamento."
+
+      - name: geography
+        description: "Geografia do equipamento (ST_GEOGPOINT)."
+
+      - name: status_ativo
+        description: "Equipamento ativo ou não."
+
   - name: radar
     description: |
       **Descrição**: Tabela que contém os dados dos radares da CETRIO.


### PR DESCRIPTION
## Principais alterações

### dbt (`queries/`)

- **Novo model** `ponto_coleta_lpr_camera_proxima`: liga pontos de coleta (`ponto_coleta_lpr`, chave `id_ponto_coleta`) às câmeras mais próximas (`cameras`), com ranking por distância; `cluster_by` em `id_ponto_coleta`.
- **`radares_cameras_proximas`**: correção alinhada ao mesmo padrão espacial / colunas (conforme diff do commit de fix).
- **`schema.yml` (cerco_digital)**: documentação, colunas e testes para o novo model (e ajustes associados ao fix do radar).

### Prefect (`pipelines/`)

- **`cerco_digital_staging/radar`**: removido o schedule autónomo do flow de materialização de radares; o flow continua disponível para ser disparado por outros flows.
- **`cerco_digital/auxiliary_tables`**: o flow de tabelas auxiliares passa a **criar um flow run** do `materialize_radar` **antes** do run do dbt transform, com dependência upstream; parâmetros `vars` do dbt passam pela task `add_default_start_date_to_dbt_vars` para o `start_date` ser calculado em **runtime** (evita o mesmo `start_date` em vários runs agendados).
- **`cerco_digital/readings`**: ajustes em `flows.py` / `schedules.py` (alinhados ao mesmo tipo de orquestração / parâmetros).
- **`pipelines/utils/tasks.py`**: task `add_default_start_date_to_dbt_vars` (merge de `vars` + data de início truncada à hora corrente em UTC).
- **`templates/run_dbt_model/flows.py`**: alteração pontual.